### PR TITLE
Get rid of Python 2 - Python 3 is now default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Usage
 First you need to define a root directory where all the JSON files will be exported. Then you need
 to proceed your network capture files to generate the JSON files:
 
-    ./potiron-json-ipsumpdump.py -k -r /tmp/test-honeypot-1-20140826000000.cap.gz -d ../out/
+    ./potiron-json-ipsumpdump.py -c -r /tmp/test-honeypot-1-20140826000000.cap.gz -d ../out/
     potiron[24989]: [INFO] Created filename ../out/2014/08/26/test-honeypot-1-20140826000000.json
 
 Then the JSON file can be imported into the Redis database:

--- a/bin/potiron-json-ipsumpdump.py
+++ b/bin/potiron-json-ipsumpdump.py
@@ -30,13 +30,13 @@ import datetime
 
 
 def usage():
-    print("""potiron-json-ipsumpdump.py [-h] [-r filename]  [-d directory] [-k]
+    print("""potiron-json-ipsumpdump.py [-h] [-r filename]  [-d directory] [-c]
 
     -h              Shows this screen
     -d directory    Specify the directory where the files should be stored
     -r filename     Specify the pcap filename that should be dissected by
                     ipsumdump
-    -k              Log data also sent to console and not only to syslog
+    -c              Log data also sent to console and not only to syslog
                     The filename is specified with the -r option
 
 FILENAME CONVENTION
@@ -133,7 +133,7 @@ def process_file(rootdir, filename):
                              "-f", potiron.bpffilter, "-r", filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     for line in proc.stdout.readlines():
         packet_id = packet_id + 1
-        line = line[:-1]
+        line = line[:-1].decode()
         timestamp, length, protocol, ipsrc, ipdst, ipop, ipttl, iptos, sport, dport, icmpcode, icmptype = line.split(' ')
         ilength = -1
         iipttl = -1
@@ -161,7 +161,6 @@ def process_file(rootdir, filename):
         dobj = datetime.datetime.fromtimestamp(float(a))
         stime = dobj.strftime("%Y-%m-%d %H:%M:%S")
         stime = stime + "." + b
-
         packet = {'timestamp': stime,
                   'length': ilength,
                   'protocol': numerize_proto(protocol),


### PR DESCRIPTION
stdin lines are in byte streams and typo in args fixed