### PR TITLE
Formalized parameters, new module, some documentation, and key 'BPF' in both redis versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,24 +62,24 @@ Then the JSON file can be imported into the Redis database:
 
 Some specific data fields can be represented into graphics (multiple values can be specified after parameter '-v') :
 
-	./bokeh-export.py -s test-honeypot-1 -f dport -v 22 -d 201703 -u /tmp/redis.sock -o ./out/ --logo /home/user/Pictures/logo.png
+	./bokeh-export.py -s test-honeypot-1 -f dport -v 22 -d 2017-03 -u /tmp/redis.sock -o ./out/ --logo /home/user/Pictures/logo.png
 
 The last parameter --logo is optionnal and is the ABSOLUTE path of the logo file which will be displayed. If no argument is given, the default file is the CIRCL logo stored in the doc/ directory of potiron.
 
 In order to have working redirections in this plot, the resulting graphs should be created first. To do so, .csv files should be processed :
 
-	./export-csv-all-days-per-month.py -s test-honeypot-1 -f dport -d 201703 -u /tmp/redis.sock -o ./out/ -l 10 --skip -1
+	./export-csv-all-days-per-month.py -s test-honeypot-1 -f dport -d 2017-03 -u /tmp/redis.sock -o ./out/ -l 10 --skip -1
 
 The -l parameter is used to define the number of most frequent values to display (default number is 20)
 The --skip parameter can be used to specify values to exclude in the graph.
 
 Each one of these files can also be reprocessed separatly:
 
-	./export-csv-day.py -s test-honeypot-1 -f dport -d 20170301 -u /tmp/redis.conf -o ./out/ -l 10 --skip -1
+	./export-csv-day.py -s test-honeypot-1 -f dport -d 2017-03-01 -u /tmp/redis.conf -o ./out/ -l 10 --skip -1
 
 Statistics for an entire month can also be displayed as well. The data file used in this case is created with the following :
 
-	./export-csv-month.py -s test-honeypot-1 -f dport -d 201703 -u /tmp/redis.conf -o ./out/ -l 10 --skip -1
+	./export-csv-month.py -s test-honeypot-1 -f dport -d 2017-03 -u /tmp/redis.conf -o ./out/ -l 10 --skip -1
 
 These files contain the data which will be used as data source in the graphs. The next step to do is creating the graphs with the data sources.
 

--- a/bin/bokeh-export.py
+++ b/bin/bokeh-export.py
@@ -70,9 +70,9 @@ if __name__ == '__main__':
 
     # Define the date of the data to select
     if args.date is None:
-        sys.stderr.write('A date must be specified.\nThe format is : YYYYMM')
+        sys.stderr.write('A date must be specified.\nThe format is : YYYY-MM\n')
         sys.exit(1)
-    date = args.date[0]
+    date = args.date[0].replace("-","")
 
     # Define the occurrences to select for the given field
     if args.values is None:
@@ -85,6 +85,8 @@ if __name__ == '__main__':
         outputdir = "./out/"
     else:
         outputdir = args.outputdir[0]
+        if not outputdir.endswith('/'):
+            outputdir = "{}/".format(outputdir)
     if not os.path.exists(outputdir):
         os.makedirs(outputdir)
 

--- a/bin/export-csv-all-days-per-month.py
+++ b/bin/export-csv-all-days-per-month.py
@@ -26,9 +26,9 @@ else:
     source = args.source[0]
 
 if args.date is None:
-    sys.stderr.write('A date must be specified.\nThe format is : YYYYMM\n')
+    sys.stderr.write('A date must be specified.\nThe format is : YYYY-MM\n')
     sys.exit(1)
-date = args.date[0]
+date = args.date[0].replace("-","")
 
 if args.field is None:
     sys.stderr.write('A field must be specified.\n')
@@ -47,6 +47,8 @@ if args.outputdir is None:
     outputdir = "./out/"
 else:
     outputdir = args.outputdir[0]
+    if not outputdir.endswith('/'):
+        outputdir = "{}/".format(outputdir)
 if not os.path.exists(outputdir):
     os.makedirs(outputdir)
 

--- a/bin/export-csv-all-days-per-month.py
+++ b/bin/export-csv-all-days-per-month.py
@@ -7,9 +7,11 @@ import os
 import calendar
 from potiron_graph_annotation import field2string,bubble_annotation
 
+# Definition of the output file name
 def output_name(source, field, dest, yearmonth, day):
     return "{}{}_{}_{}-{}-{}".format(dest,source,field,yearmonth[0:4],yearmonth[4:6],day)
 
+# Parameters parser
 parser = argparse.ArgumentParser(description='Export one month data from redis')
 parser.add_argument("-s","--source", type=str, nargs=1, help="Data source")
 parser.add_argument("-d","--date", type=str, nargs=1, help='Date of the informations to display')
@@ -58,23 +60,30 @@ if args.unix is None:
 usocket = args.unix[0]
 r = redis.Redis(unix_socket_path=usocket)
 
+# Project directory
 potiron_path = os.path.dirname(os.path.realpath(__file__))[:-3]
 
+# Definition of the strings containing the informations of the field, used in the legend and the file name
 field_string, field_in_file_name = field2string(field, potiron_path)
 
 days = calendar.monthrange(int(date[0:4]),int(date[4:6]))[1]
+# For each day of the month
 for d in range(1,days+1):
     redisKey = "{}:{}{}:{}".format(source, date, format(d, '02d'), field)
     if r.exists(redisKey):
         l = 0
         values = []
+        # For each value ranged in decreasing order
         for v in r.zrevrangebyscore(redisKey,sys.maxsize,0):
             val = v.decode()
+            # If the current value is not one that should be skipped, increment the number of values to include in the chart
             if val not in args.skip :
                 values.append(val)
                 l += 1
+            # When the limit value is reached, we don't need to increment anymore, we break the loop
             if l >= limit:
                 break
+        # Write all the values and their scores into the csv datafile
         with open("{}.csv".format(output_name(source,field_in_file_name,outputdir,date,format(d, '02d'))),'w') as f:
             f.write("id,value\n")
             for v in values:

--- a/bin/export-csv-day.py
+++ b/bin/export-csv-day.py
@@ -25,9 +25,9 @@ else:
     source = args.source[0]
 
 if args.date is None:
-    sys.stderr.write('A date must be specified.\nThe format is : YYYYMMDD')
+    sys.stderr.write('A date must be specified.\nThe format is : YYYY-MM-DD')
     sys.exit(1)
-date = args.date[0]
+date = args.date[0].replace("-","")
 
 if args.field is None:
     sys.stderr.write('A field must be specified.\n')
@@ -46,6 +46,8 @@ if args.outputdir is None:
     outputdir = "./out/"
 else:
     outputdir = args.outputdir[0]
+    if not outputdir.endswith('/'):
+        outputdir = "{}/".format(outputdir)
 if not os.path.exists(outputdir):
     os.makedirs(outputdir)
 

--- a/bin/export-csv-day.py
+++ b/bin/export-csv-day.py
@@ -6,9 +6,11 @@ import sys
 import os
 from potiron_graph_annotation import field2string,bubble_annotation
 
+# Definition of the output file name
 def output_name(source, field, date, dest):
     return "{}{}_{}_{}-{}-{}".format(dest,source,field,date[0:4],date[4:6],date[6:8])
 
+# Parameters parser
 parser = argparse.ArgumentParser(description='Export one day data from redis')
 parser.add_argument("-s","--source", type=str, nargs=1, help="Data source")
 parser.add_argument("-d","--date", type=str, nargs=1, help='Date of the informations to display')
@@ -57,21 +59,27 @@ if args.unix is None:
 usocket = args.unix[0]
 r = redis.Redis(unix_socket_path=usocket)
 
+# Project directory
 potiron_path = os.path.dirname(os.path.realpath(__file__))[:-3]
 
+# Definition of the strings containing the informations of the field, used in the legend and the file name
 field_string, field_in_file_name = field2string(field, potiron_path)
 
 redisKey = "{}:{}:{}".format(source, date, field)
 if r.exists(redisKey):
     l = 0
     values = []
+    # For each value ranged in decreasing order
     for v in r.zrevrangebyscore(redisKey,sys.maxsize,0):
         val = v.decode()
+        # If the current value is not one that should be skipped, increment the number of values to include in the chart
         if val not in args.skip :
             values.append(val)
             l += 1
+        # When the limit value is reached, we don't need to increment anymore, we break the loop
         if l >= limit:
             break
+    # Write all the values and their scores into the csv datafile
     with open("{}.csv".format(output_name(source,field_in_file_name,date,outputdir)),'w') as f:
         f.write("id,value\n")
         for v in values:

--- a/bin/export-csv-month.py
+++ b/bin/export-csv-month.py
@@ -7,9 +7,11 @@ import os
 import calendar
 from potiron_graph_annotation import field2string,bubble_annotation
 
+# Definition of the output file name
 def output_name(source, field, date, dest):
     return "{}{}_{}_{}-{}".format(dest,source,field,date[0:4],date[4:6])
 
+# Parameters parser
 parser = argparse.ArgumentParser(description='Export one month data from redis')
 parser.add_argument("-s","--source", type=str, nargs=1, help="Data source")
 parser.add_argument("-d","--date", type=str, nargs=1, help='Date of the informations to display')
@@ -24,7 +26,6 @@ if args.source is None:
     source = "potiron"
 else:
     source = args.source[0]
-    
 
 if args.date is None:
     sys.stderr.write('A date must be specified.\nThe format is : YYYY-MM')
@@ -59,34 +60,45 @@ if args.unix is None:
 usocket = args.unix[0]
 r = redis.Redis(unix_socket_path=usocket)
 
+# Project directory
 potiron_path = os.path.dirname(os.path.realpath(__file__))[:-3]
 
+# Definition of the strings containing the informations of the field, used in the legend and the file name
 field_string, field_in_file_name = field2string(field, potiron_path)
 
 days = calendar.monthrange(int(date[0:4]),int(date[4:6]))[1]
-score={}                            
+score={}
+# For each day of the month                           
 for d in range(1,days+1):
     redisKey = "{}:{}{}:{}".format(source, date, format(d, '02d'), field)
     if r.exists(redisKey):
+        # For each value ranged in decreasing order
         for v in r.zrangebyscore(redisKey,0,sys.maxsize):
             countValue = r.zscore(redisKey,v)
             val = v.decode()
+            # If the current value has to be skipped, go to the next iteration of the loop
             if val in args.skip :
                 continue
+            # If the current value is already present in the list of values, increment the score with the current score
             if val in score:
                 score[val]+=countValue
+            # On the other  case, add the value with its score in the list 
             else:
                 score[val]=countValue
 
+# Sort the complete list of values for the month by score
 res = list(sorted(score, key=score.__getitem__, reverse=True))
 l = 0
 values = []
 for s in res:
+    # If the current value is not one that should be skipped, increment the number of values to include in the chart
     if s not in args.skip:
         values.append(s)
         l += 1
+    # When the limit value is reached, we don't need to increment anymore, we break the loop
     if l >= limit:
         break
+ # Write all the values and their scores into the csv datafile
 with open("{}.csv".format(output_name(source,field_in_file_name,date,outputdir)),'w') as f:
     f.write("id,value\n")
     for v in values :

--- a/bin/export-csv-month.py
+++ b/bin/export-csv-month.py
@@ -27,9 +27,9 @@ else:
     
 
 if args.date is None:
-    sys.stderr.write('A date must be specified.\nThe format is : YYYYMM')
+    sys.stderr.write('A date must be specified.\nThe format is : YYYY-MM')
     sys.exit(1)
-date = args.date[0]
+date = args.date[0].replace("-","")
 
 if args.field is None:
     sys.stderr.write("A field must be specified.\n")
@@ -48,6 +48,8 @@ if args.outputdir is None:
     outputdir = "./out/"
 else:
     outputdir = args.outputdir[0]
+    if not outputdir.endswith('/'):
+        outputdir = "{}/".format(outputdir)
 if not os.path.exists(outputdir):
     os.makedirs(outputdir)
     

--- a/bin/isn-pcap-process-day.py
+++ b/bin/isn-pcap-process-day.py
@@ -122,6 +122,8 @@ if __name__ == '__main__':
         outputdir = "./out/"
     else:
         outputdir = args.outputdir[0]
+        if not outputdir.endswith('/'):
+            outputdir = "{}/".format(outputdir)
     if not os.path.exists(outputdir):
         os.makedirs(outputdir)
     process_isn(src_dir,source,outputdir)

--- a/bin/isn-pcap-process-day.py
+++ b/bin/isn-pcap-process-day.py
@@ -104,24 +104,24 @@ def process_isn(src_dir,source,output):
 if __name__ == '__main__':
     # Parameters parser
     parser = argparse.ArgumentParser(description="Show ISN values")
-    parser.add_argument("-i", "--input", type=str, nargs=1, help="Source directory for the files to process")
+    parser.add_argument("-i", "--inputdir", type=str, nargs=1, help="Source directory for the files to process")
     parser.add_argument("-s", "--source", type=str, nargs=1, help="Honeypot data source")
     parser.add_argument("-o", "--outputdir", type=str, nargs=1, help="Destination path for the output file")
     args = parser.parse_args()
 
-    if args.input is None:
+    if args.inputdir is None:
         errormsg("A source directory should be defined")
         sys.exit(1)
-    src_dir = args.input[0]
+    src_dir = args.inputdir[0]
     if args.source is None:
         source = "potiron"
     else:
         source = args.source[0]
 
     if args.outputdir is None:
-        output = "./out/"
+        outputdir = "./out/"
     else:
-        output = args.outputdir[0]
-    if not os.path.exists(output):
-        os.makedirs(output)
-    process_isn(src_dir,source,output)
+        outputdir = args.outputdir[0]
+    if not os.path.exists(outputdir):
+        os.makedirs(outputdir)
+    process_isn(src_dir,source,outputdir)

--- a/bin/isn-pcap.py
+++ b/bin/isn-pcap.py
@@ -39,6 +39,8 @@ def time_space(hour):
 
 # Process the ISN graphs directly from pcap files
 def process_isn(src_dir,source,hour,outputdir,seq,ack):
+    if not os.path.exists(outputdir):
+        os.makedirs(outputdir)
     w_input = []
     x_input = []
     y_input = []
@@ -123,8 +125,6 @@ def process_isn(src_dir,source,hour,outputdir,seq,ack):
     output_file_name = "{}{}{}".format(outputdir,outputname,type_string)
 #    output_file("{}{}{}.html".format(outputdir,outputname,type_string),
 #            title="TCP ISN values in Honeypot", mode='inline')
-    if not os.path.exists(outputdir):
-            os.makedirs(outputdir)
     output_file("{}.html".format(output_file_name),
             title="TCP ISN values in Honeypot", mode='inline')
     if seq and ack:
@@ -136,17 +136,17 @@ def process_isn(src_dir,source,hour,outputdir,seq,ack):
 if __name__ == '__main__':
     # Parameters parser
     parser = argparse.ArgumentParser(description="Show ISN values")
-    parser.add_argument("-i", "--input", type=str, nargs=1, help="Source directory for the files to process")
+    parser.add_argument("-i", "--inputdir", type=str, nargs=1, help="Source directory for the files to process")
     parser.add_argument("-s", "--source", type=str, nargs=1, help="Honeypot data source")
-    parser.add_argument("--hour", type=str, nargs=1, help="Hour of the informations wanted in the day selected")
+    parser.add_argument("-hr", "--hour", type=str, nargs=1, help="Hour of the informations wanted in the day selected")
     parser.add_argument("-t", "--type", type=str, nargs=1, help="Type of number : sequence or acknowledgement")
     parser.add_argument("-o", "--outputdir", type=str, nargs=1, help="Destination path for the output file")
     args = parser.parse_args()
 
-    if args.input is None:
+    if args.inputdir is None:
         errormsg("A source directory should be defined")
         sys.exit(1)
-    src_dir = args.input[0]
+    src_dir = args.inputdir[0]
     if args.source is None:
         source = "potiron"
     else:
@@ -171,7 +171,7 @@ if __name__ == '__main__':
             or simply not use any of these to display both sequence and acknowledgement numbers')
             sys.exit(1)
     if args.outputdir is None:
-        output = "./out/"
+        outputdir = "./out/"
     else:
-        output = args.outputdir[0]
-    process_isn(src_dir,source,hour,output,seq,ack)
+        outputdir = args.outputdir[0]
+    process_isn(src_dir,source,hour,outputdir,seq,ack)

--- a/bin/isn-pcap.py
+++ b/bin/isn-pcap.py
@@ -174,4 +174,6 @@ if __name__ == '__main__':
         outputdir = "./out/"
     else:
         outputdir = args.outputdir[0]
+        if not outputdir.endswith('/'):
+            outputdir = "{}/".format(outputdir)
     process_isn(src_dir,source,hour,outputdir,seq,ack)

--- a/bin/isn-redis-process-day.py
+++ b/bin/isn-redis-process-day.py
@@ -91,6 +91,7 @@ if __name__ == '__main__':
     # For each hour of the day
     for hours in range(sh,eh):
         h = format(hours, '02d')
+        # if no port filter is defined
         if args.port_filter is None:
             key = "{}*{}_{}".format(source,date,h)
             # If there is no key corresponding to a precise hour, go directly is the next hour

--- a/bin/isn-redis-process-day.py
+++ b/bin/isn-redis-process-day.py
@@ -37,11 +37,11 @@ if __name__ == '__main__':
     # Parameters parser
     parser = argparse.ArgumentParser(description="Show ISN values")
     parser.add_argument("-d", "--date", type=str, nargs=1, help="Date of the files to process")
-    parser.add_argument("--hour", type=str, nargs=1, help="Hour of the informations wanted in the day selected")
+    parser.add_argument("-hr", "--hour", type=str, nargs=1, help="Hour of the informations wanted in the day selected")
     parser.add_argument("-s", "--source", type=str, nargs=1, help="Honeypot data source")
     parser.add_argument("-o", "--outputdir", type=str, nargs=1, help="Destination path for the output file")
     parser.add_argument("-u", "--unix", type=str, nargs =1, help="Unix socket to connect to redis-server")
-    parser.add_argument("-t", "--timeline", type=int, nargs=1, help="Timeline used to split data in graphs")
+    parser.add_argument("-tl", "--timeline", type=int, nargs=1, help="Timeline used to split data in graphs")
     parser.add_argument("-pf", "--port_filter", nargs='+', help="Filter the ports you want to display")
     args = parser.parse_args()
 
@@ -66,11 +66,11 @@ if __name__ == '__main__':
     else:
         source = args.source[0]
     if args.outputdir is None:
-        output = "./out/"
+        outputdir = "./out/"
     else:
-        output = args.outputdir[0]
-    if not os.path.exists(output):
-        os.makedirs(output)
+        outputdir = args.outputdir[0]
+    if not os.path.exists(outputdir):
+        os.makedirs(outputdir)
     if args.unix is None:
         sys.stderr.write('A unix socket must be specified\n')
         sys.exit(1)
@@ -160,7 +160,7 @@ if __name__ == '__main__':
                     p_ack.yaxis[0].formatter = BasicTickFormatter(use_scientific=False)
                     p_ack.scatter(x, w, color=colorsack, legend="ack values", alpha=0.5, )
                     output_name = "color_scatter_{}_{}_{}-{}_syn+ack".format(source,date,start_hour,end_hour)
-                    output_dir = "{}{}/{}/{}/{}".format(output,date.split('-')[0],date.split('-')[1],date.split('-')[2],h)
+                    output_dir = "{}{}/{}/{}/{}".format(outputdir,date.split('-')[0],date.split('-')[1],date.split('-')[2],h)
                     if not os.path.exists(output_dir):
                         os.makedirs(output_dir)
                     output_file("{}/{}.html".format(output_dir,output_name),
@@ -228,7 +228,7 @@ if __name__ == '__main__':
                 p_seq.legend.click_policy = "hide"
                 p_ack.legend.click_policy = "hide"
                 output_name = "color_scatter_{}_{}_{}-{}_syn+ack".format(source,date,start_hour,end_hour)
-                output_dir = "{}{}/{}/{}/{}".format(output,date.split('-')[0],date.split('-')[1],date.split('-')[2],h)
+                output_dir = "{}{}/{}/{}/{}".format(outputdir,date.split('-')[0],date.split('-')[1],date.split('-')[2],h)
                 if not os.path.exists(output_dir):
                     os.makedirs(output_dir)
                 output_file("{}/{}.html".format(output_dir,output_name),

--- a/bin/isn-redis-process-day.py
+++ b/bin/isn-redis-process-day.py
@@ -69,6 +69,8 @@ if __name__ == '__main__':
         outputdir = "./out/"
     else:
         outputdir = args.outputdir[0]
+        if not outputdir.endswith('/'):
+            outputdir = "{}/".format(outputdir)
     if not os.path.exists(outputdir):
         os.makedirs(outputdir)
     if args.unix is None:

--- a/bin/isn-redis.py
+++ b/bin/isn-redis.py
@@ -126,6 +126,8 @@ if __name__ == '__main__':
         outputdir = "./out/"
     else:
         outputdir = args.outputdir[0]
+        if not outputdir.endswith('/'):
+            outputdir = "{}/".format(outputdir)
     if not os.path.exists(outputdir):
             os.makedirs(outputdir)
     if args.unix is None:

--- a/bin/isn-redis.py
+++ b/bin/isn-redis.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Show ISN values")
     parser.add_argument("-d", "--date", type=str, nargs=1, help="Date of the files to process")
     parser.add_argument("-s", "--source", type=str, nargs=1, help="Honeypot data source")
-    parser.add_argument("--hour", type=str, nargs=1, help="Hour of the informations wanted in the day selected")
+    parser.add_argument("-hr", "--hour", type=str, nargs=1, help="Hour of the informations wanted in the day selected")
     parser.add_argument("-tl", "--timeline", type=int, nargs=1, help="Timeline of the data to display")
     parser.add_argument("-t", "--type", type=str, nargs=1, help="Type of number : sequence or acknowledgement")
     parser.add_argument("-o", "--outputdir", type=str, nargs=1, help="Destination path for the output file")
@@ -123,11 +123,11 @@ if __name__ == '__main__':
             or simply not use any of these to display both sequence and acknowledgement numbers')
             sys.exit(1)
     if args.outputdir is None:
-        output = "./out/"
+        outputdir = "./out/"
     else:
-        output = args.outputdir[0]
-    if not os.path.exists(output):
-            os.makedirs(output)
+        outputdir = args.outputdir[0]
+    if not os.path.exists(outputdir):
+            os.makedirs(outputdir)
     if args.unix is None:
         sys.stderr.write('A unix socket must be specified\n')
         sys.exit(1)
@@ -259,7 +259,7 @@ if __name__ == '__main__':
         if ack:
             p_ack.legend.click_policy = "hide"
             p = p_ack
-    output_file_name = "{}{}{}".format(output,outputname,type_string)
+    output_file_name = "{}{}{}".format(outputdir,outputname,type_string)
     output_file("{}.html".format(output_file_name),
             title="TCP ISN values in Honeypot", mode='inline')
     # In case of two plots

--- a/bin/isn-redis.py
+++ b/bin/isn-redis.py
@@ -137,6 +137,7 @@ if __name__ == '__main__':
     red = redis.Redis(unix_socket_path=usocket)
 
     TOOLS="hover,crosshair,pan,wheel_zoom,zoom_in,zoom_out,box_zoom,undo,redo,reset,tap,save,box_select,poly_select,lasso_select,"
+    # if no port filter is defined
     if args.port_filter is None:
         key = "{}*".format(source)
         w_input = []

--- a/bin/parallel-coordinate.py
+++ b/bin/parallel-coordinate.py
@@ -25,9 +25,9 @@ else:
     source = args.source[0]
 
 if args.date is None:
-    sys.stderr.write('A date must be specified.\nThe format is : YYYYMM\n')
+    sys.stderr.write('A date must be specified.\nThe format is : YYYY-MM\n')
     sys.exit(1)
-date = args.date[0]
+date = args.date[0].replace("-","")
 month = date[4:6]
 
 if args.field is None:
@@ -44,6 +44,8 @@ if args.outputdir is None:
     outputdir = "./out/"
 else:
     outputdir = args.outputdir[0]
+    if not outputdir.endswith('/'):
+        outputdir = "{}/".format(outputdir)
 if not os.path.exists(outputdir):
     os.makedirs(outputdir)
 

--- a/bin/potiron-isn-redis-from-json.py
+++ b/bin/potiron-isn-redis-from-json.py
@@ -7,7 +7,8 @@ import sys
 import os
 import potiron
 
-non_index = ['', 'timestamp', 'state', 'type', 'sport', 'dport']
+non_index = ['', 'filename', 'sensorname', 'packet_id','timestamp', 'length', 'protocol', 'sport',
+             'dport', 'ipsrc', 'ipdst', 'ipttl', 'iptos', 'icmpcode', 'icmptype', 'type', 'state']
 
 parser = argparse.ArgumentParser(description='Import json documents into redis time series')
 parser.add_argument('-i', '--input', type=str, nargs=1, help='Filename of a json document that should be imported.')

--- a/bin/potiron-isn-redis-from-json.py
+++ b/bin/potiron-isn-redis-from-json.py
@@ -51,6 +51,15 @@ rev_dics = dict()
 # Get sensorname assume one document per sensor name
 
 item = doc[0]
+bpf = item['bpf']
+if red.keys('BPF'):
+    if not red.sismember('BPF', bpf):
+        red.srem('FILES', fn)
+        bpf_string = str(red.smembers('BPF'))
+        sys.stderr.write('[INFO] BPF for the current data is not the same as the one used in the data already stored here : {}\n'.format(bpf_string[3:-2]))
+        sys.exit(0)
+else:
+    red.sadd('BPF', bpf)
 # FIXME documents must include at least a sensorname and a timestamp
 # FIXME check timestamp format
 sensorname = potiron.get_sensor_name(doc)

--- a/bin/potiron-isn-redis-from-json.py
+++ b/bin/potiron-isn-redis-from-json.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import redis
+import sys
+import os
+import potiron
+
+non_index = ['', 'timestamp', 'state', 'type', 'sport', 'dport']
+
+parser = argparse.ArgumentParser(description='Import json documents into redis time series')
+parser.add_argument('-i', '--input', type=str, nargs=1, help='Filename of a json document that should be imported.')
+parser.add_argument('-u', '--unix', type=str, nargs=1, help='Unix socket to connect to redis-server.')
+parser.add_argument('--reverse', action='store_false', help='Create global reverse dictionaries')
+args = parser.parse_args()
+
+if args.unix is None:
+    sys.stderr.write('A unix socket must be specified\n')
+    sys.exit(1)
+usocket = args.unix[0]
+
+red = redis.Redis(unix_socket_path=usocket)
+
+if not args.reverse:
+    potiron.create_reverse_global_dicts(red)
+    potiron.infomsg("Created global reverse annotation dictionaries")
+    sys.exit(0)
+
+if args.input is None:
+    sys.stderr.write('A filename must be specified\n')
+    sys.exit(1)
+filename = args.input[0]
+
+# Check if file was already imported
+fn = os.path.basename(filename)
+if red.sismember("FILES", fn):
+    sys.stderr.write('[INFO] Filename ' + fn + ' was already imported ... skip ...\n')
+    sys.exit(0)
+red.sadd("FILES", fn)
+
+f = open(filename, 'r')
+doc = json.load(f)
+f.close()
+
+# Record local dictionaries
+local_dicts = dict()
+rev_dics = dict()
+
+# Get sensorname assume one document per sensor name
+
+item = doc[0]
+# FIXME documents must include at least a sensorname and a timestamp
+# FIXME check timestamp format
+sensorname = potiron.get_sensor_name(doc)
+lastday = None
+revcreated = False
+
+for di in doc:
+    if di["type"] > potiron.DICT_LOWER_BOUNDARY:
+        local_dicts[di["type"]] = di
+    if di["type"] == potiron.TYPE_PACKET:
+        if not revcreated:
+            # FIXME if a json file was annotated twice the resulting json file
+            # includes two dictionaries of the same type
+            # Only the last one is considered
+            rev_dics = potiron.create_reverse_local_dicts(local_dicts)
+            revcreated = True
+        timestamp = di['timestamp']
+        sport = di['sport']
+        dport = di['dport']
+        (day, time) = timestamp.split(' ')
+        timestamp = "{}_{}".format(day,time)
+        day = day.replace('-', '')
+        if day != lastday:
+            red.sadd("DAYS", day)
+        p = red.pipeline()
+        for k in list(di.keys()):
+            if k not in non_index:
+                feature = di[k]
+                if k.startswith(potiron.ANNOTATION_PREFIX):
+                    feature = potiron.translate_dictionaries(rev_dics, red, k, di[k])
+                    # Create the links between annotations and their objects
+                    idn = potiron.get_dictionary_id(k)
+                    obj = potiron.get_annotation_origin(di, k)
+                    if obj is not None and idn is not None:
+                        kn = "AR_{}_{}".format(idn, obj)
+                        p.set(kn, feature)
+                keyname = "{}_src{}_dst{}_{}".format(sensorname,sport,dport,timestamp)
+                p.hset(keyname,k,feature)
+p.execute()

--- a/bin/potiron-isn-redis.py
+++ b/bin/potiron-isn-redis.py
@@ -137,9 +137,9 @@ def process_file(outputdir, filename):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Start the tool tshark and store data into a json document and redis in the same time')
-    parser.add_argument('-i', '--filename', type=str, nargs=1, help='Pcap or compressed pcap filename.')
+    parser.add_argument('-i', '--input', type=str, nargs=1, help='Pcap or compressed pcap filename.')
     parser.add_argument('-u', '--unix', type=str, nargs=1, help='Unix socket to connect to redis-server.')
-    parser.add_argument('-o', '--output', type=str, nargs=1, help='Json output file')
+    parser.add_argument('-o', '--outputdir', type=str, nargs=1, help='Json file output directory')
     parser.add_argument("-bf", "--bpffilter", type=str, nargs='+', help="BPF Filter")
     parser.add_argument('--reverse', action='store_false', help='Create global reverse dictionaries')
     args = parser.parse_args()
@@ -157,10 +157,10 @@ if __name__ == '__main__':
         potiron.infomsg("Created global reverse annotation dictionaries")
         sys.exit(0)
 
-    if args.filename is None:
-        sys.stderr.write('A filename must be specified\n')
+    if args.input is None:
+        sys.stderr.write('An input filename must be specified\n')
         sys.exit(1)
-    filename = args.filename[0]
+    filename = args.input[0]
 
     if args.bpffilter is not None:
         if len(args.bpffilter) == 1:
@@ -178,10 +178,10 @@ if __name__ == '__main__':
         sys.exit(0)
     red.sadd("FILES", fn)
 
-    if args.output is None:
+    if args.outputdir is None:
         sys.stderr.write('An output directory must be specified\n')
     else:
-        outputdir = args.output[0]
+        outputdir = args.outputdir[0]
         create_dirs(outputdir, filename)
         if os.path.isdir(outputdir) is False:
             sys.stderr.write("The root directory is not a directory\n")

--- a/bin/potiron-json-ipsumpdump.py
+++ b/bin/potiron-json-ipsumpdump.py
@@ -223,29 +223,29 @@ def process_file(rootdir, filename):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Start the too ipsumpdump and transform the output in a json document")
-    parser.add_argument("-r", "--read", type=str, nargs=1, help="Compressed pcap file or pcap filename")
+    parser.add_argument("-i", "--input", type=str, nargs=1, help="Compressed pcap file or pcap filename")
     parser.add_argument("-c", "--console", action='store_true', help="Log output also to console")
-    parser.add_argument("-o", "--directory", nargs=1, help="Output directory where the json documents are stored")
+    parser.add_argument("-o", "--outputdir", nargs=1, help="Output directory where the json documents are stored")
 
     args = parser.parse_args()
     potiron.logconsole = args.console
-    if args.read is not None:
-        if os.path.exists(args.read[0]) is False:
-            errormsg("The filename {} was not found".format(args.read[0]))
+    if args.input is None:
+        errormsg("At least a pcap file must be specified")
+        sys.exit(1)
+    else:
+        if os.path.exists(args.input[0]) is False:
+            errormsg("The filename {} was not found".format(args.input[0]))
             sys.exit(1)
 
-    if args.directory is not None and os.path.isdir(args.directory[0]) is False:
+    if args.outputdir is not None and os.path.isdir(args.outputdir[0]) is False:
         errormsg("The root directory is not a directory")
         sys.exit(1)
 
-    if args.read is None:
-        errormsg("At least a pcap file must be specified")
-        sys.exit(1)
     try:
         rootdir = None
-        if args.directory is not None:
-            rootdir = args.directory[0]
-        process_file(rootdir, args.read[0])
+        if args.outputdir is not None:
+            rootdir = args.outputdir[0]
+        process_file(rootdir, args.input[0])
     except OSError as e:
         errormsg("A processing error happend.{}.\n".format(e))
         sys.exit(1)

--- a/bin/potiron-json-tshark.py
+++ b/bin/potiron-json-tshark.py
@@ -13,7 +13,7 @@ import datetime
 import potiron_redis
 
 
-bpf_filter = potiron.tshark_filter
+bpf = potiron.tshark_filter
 
 
 # Save the output json file
@@ -94,7 +94,7 @@ def process_file(rootdir, filename, fieldfilter, b_redis, ck):
     allpackets = []
     # Describe the source
     allpackets.append({"type": potiron.TYPE_SOURCE, "sensorname": sensorname,
-                       "filename": os.path.basename(filename)})
+                       "filename": os.path.basename(filename), "bpf": bpf})
     # Each packet as a incremental numeric id
     # A packet is identified with its sensorname filename and packet id for
     # further aggregation with meta data.
@@ -112,7 +112,7 @@ def process_file(rootdir, filename, fieldfilter, b_redis, ck):
     else:
         for f in tshark_fields:
             cmd += "-e {} ".format(f)
-    cmd += "-E header=n -E separator=/s -E occurrence=f -Y '{}' -r {} -o tcp.relative_sequence_numbers:FALSE".format(bpf_filter, filename)
+    cmd += "-E header=n -E separator=/s -E occurrence=f -Y '{}' -r {} -o tcp.relative_sequence_numbers:FALSE".format(bpf, filename)
 
     proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     json_fields = potiron.json_fields
@@ -182,14 +182,14 @@ if __name__ == '__main__':
     else:
         fieldfilter = args.fieldfilter
 
-    if args.bpffilter is not None:
-        if len(args.bpffilter) == 1:
-            bpffilter = args.bpffilter[0]
+    if args.bpfilter is not None:
+        if len(args.bpfilter) == 1:
+            bpfilter = args.bpfilter[0]
         else:
-            bpffilter = ""
-            for f in args.bpffilter:
-                bpffilter += "{} ".format(f)
-        bpf_filter += " && {}".format(bpffilter)
+            bpfilter = ""
+            for f in args.bpfilter:
+                bpfilter += "{} ".format(f)
+        bpf += " && {}".format(bpfilter)
 
     b_redis = args.redis
 

--- a/bin/potiron-json-tshark.py
+++ b/bin/potiron-json-tshark.py
@@ -159,21 +159,24 @@ def process_file(rootdir, filename, fieldfilter, b_redis, ck):
 if __name__ == '__main__':
     # Parameters parser
     parser = argparse.ArgumentParser(description="Start the tool tshark and transform the output in a json document")
-    parser.add_argument("-i", "--read", type=str, nargs=1, help="Compressed pcap file or pcap filename")
+    parser.add_argument("-i", "--input", type=str, nargs=1, help="Compressed pcap file or pcap filename")
     parser.add_argument("-c", "--console", action='store_true', help="Log output also to console")
     parser.add_argument("-ff", "--fieldfilter", nargs='+',help="Parameters to filter fields to display")
-    parser.add_argument("-o", "--directory", nargs=1, help="Output directory where the json documents are stored")
-    parser.add_argument("-bf", "--bpffilter", type=str, nargs='+', help="BPF Filter")
+    parser.add_argument("-o", "--outputdir", nargs=1, help="Output directory where the json documents are stored")
+    parser.add_argument("-bf", "--bpfilter", type=str, nargs='+', help="Berkeley Packet Filter")
     parser.add_argument("-r", "--redis", action='store_true', help="Store data directly in redis")
     parser.add_argument('-u','--unix', type=str, nargs=1, help='Unix socket to connect to redis-server.')
     parser.add_argument('-ck', '--combined_keys', action='store_true', help='Set if combined keys should be used')
     args = parser.parse_args()
     potiron.logconsole = args.console
-    if args.read is not None:
-        if os.path.exists(args.read[0]) is False:
-            sys.stderr.write("The filename {} was not found\n".format(args.read[0]))
+    if args.input is None:
+        sys.stderr.write("At least a pcap file must be specified\n")
+        sys.exit(1)
+    else:
+        if os.path.exists(args.input[0]) is False:
+            sys.stderr.write("The filename {} was not found\n".format(args.input[0]))
             sys.exit(1)
-        inputfile = args.read[0]
+        inputfile = args.input[0]
     if args.fieldfilter is None:
         fieldfilter = []
     else:
@@ -197,17 +200,13 @@ if __name__ == '__main__':
         usocket = args.unix[0]
         red = redis.Redis(unix_socket_path=usocket)
 
-    if args.read is None:
-        sys.stderr.write("At least a pcap file must be specified\n")
-        sys.exit(1)
-
     ck = args.combined_keys
 
-    if args.directory is None:
+    if args.outputdir is None:
         sys.stderr.write("You should specify an output directory.\n")
         sys.exit(1)
     else:
-        rootdir = args.directory[0]
+        rootdir = args.outputdir[0]
         create_dirs(rootdir, inputfile)
         if os.path.isdir(rootdir) is False:
             sys.stderr.write("The root directory is not a directory\n")

--- a/bin/potiron_redis.py
+++ b/bin/potiron_redis.py
@@ -48,6 +48,15 @@ def process_storage(filename, red, ck):
     # Get sensorname assume one document per sensor name
 
     item = doc[0]
+    bpf = item['bpf']
+    if red.keys('BPF'):
+        if not red.sismember('BPF', bpf):
+            red.srem('FILES', fn)
+            bpf_string = str(red.smembers('BPF'))
+            sys.stderr.write('[INFO] BPF for the current data is not the same as the one used in the data already stored here : {}\n'.format(bpf_string[3:-2]))
+            sys.exit(0)
+    else:
+        red.sadd('BPF', bpf)
     # FIXME documents must include at least a sensorname and a timestamp
     # FIXME check timestamp format
     sensorname = potiron.get_sensor_name(doc)

--- a/bin/potiron_redis.py
+++ b/bin/potiron_redis.py
@@ -98,7 +98,7 @@ def process_storage(filename, red, ck):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Import json documents\
     into redis.')
-    parser.add_argument('-i', '--filename', type=str, nargs=1, help='Filename of a json document that should be imported.')
+    parser.add_argument('-i', '--input', type=str, nargs=1, help='Filename of a json document that should be imported.')
     parser.add_argument('-u', '--unix', type=str, nargs=1, help='Unix socket to connect to redis-server.')
     parser.add_argument('-ck', '--combined_keys', action='store_true', help='Set if combined keys should be used')
     parser.add_argument('--reverse', action='store_false', help='Create global reverse dictionaries')
@@ -119,9 +119,9 @@ if __name__ == '__main__':
         potiron.infomsg("Created global reverse annotation dictionaries")
         sys.exit(0)
 
-    if args.filename is None:
+    if args.input is None:
         sys.stderr.write('A filename must be specified\n')
         sys.exit(1)
-    filename = args.filename[0]
+    filename = args.input[0]
 
     process_storage(filename, red, ck)


### PR DESCRIPTION
New module is the equivalent of "potiron_redis" module, but for ISN redis

As the key 'BPF' contains only one value, at the moment the bpf cannot be written differently for 2 different json datafiles that should have the same filter (for example 'ip.dst ne 255.255.255.255' and 'ip.dst != 255.255.255.255' are the same filters), otherwise the value stored in the key 'BPF' will be the one of the first file processed, and the second file will be rejected